### PR TITLE
Recommend writing a sentence per line

### DIFF
--- a/contents/parts/formatting-and-links.adoc
+++ b/contents/parts/formatting-and-links.adoc
@@ -2,6 +2,25 @@
 
 A common decision that a writer needs to make is whether to style a particular piece of text and if so, what style to use. This section tackles those decisions as well as those around the usage of hyperlinks.
 
+=== Write a sentence per line
+
+Asciidoctor provides the powerful ability to write a sentence per line.
+This is possible because it renders contiguous lines as a paragraph.
+The idea of this writing technique is to give every sentence, or independent clause, its own line.
+Some of the benefits to writing content this way are:
+
+* The Git diff of a sentence is easier to read when it is isolated to a single line
+** This helps reviewing changes faster
+* It calls attention to potentially long-winded sentences
+* Sentences containing long lists can be expanded to multiple lines
+** List items within these sentences can be easily added or removed
+* Individual sentences can be commented out using Asciidoctor's comments
+* Sentences can be swapped by swapping the content of two lines
+* It gives the source document a similar to feel code
+** Though it can be done, it is rare to write multiple statements per line in code
+
+Therefore, to improve the readability and user-friendliness of the guide's source, avoid writing a paragraph, or multiple sentences, on a single line.
+
 === Use permalinks to external content
 
 Some URLs point to content that changes over time. For example, URLs to the current Gradle User Manual. Prefer permalinks in place of these. Such permalinks are typically tied to a snapshot in time, for example a specific release of Gradle.

--- a/contents/parts/formatting-and-links.adoc
+++ b/contents/parts/formatting-and-links.adoc
@@ -4,9 +4,13 @@ A common decision that a writer needs to make is whether to style a particular p
 
 === Write a sentence per line
 
+:uri-adoc-zen: https://youtu.be/Aq2USmIItrs?t=3505
+:link-adoc-zen: {uri-adoc-zen}[Dan Allen's "Discover the Zen of Writing With Asciidoctor" talk]
+
 Asciidoctor provides the powerful ability to write a sentence per line.
-This is possible because it renders contiguous lines as a paragraph.
 The idea of this writing technique is to give every sentence, or independent clause, its own line.
+This is possible because Asciidoctor renders contiguous lines as a paragraph.
+More information about this technique can be learned from {link-adoc-zen}.
 Some of the benefits to writing content this way are:
 
 * The Git diff of a sentence is easier to read when it is isolated to a single line.

--- a/contents/parts/formatting-and-links.adoc
+++ b/contents/parts/formatting-and-links.adoc
@@ -27,7 +27,7 @@ Some benefits of writing content this way are:
 * It gives the document's source a similar feel to code.
 ** Though it may be allowed, it is rare to write multiple statements per line of code.
 
-Therefore, to improve the readability and user-friendliness of the guide's source, avoid writing a paragraph, or multiple sentences, on a single line.
+Therefore, to improve the readability and user-friendliness of the guide's source, use the technique of writing one sentence per line.
 
 === Use permalinks to external content
 

--- a/contents/parts/formatting-and-links.adoc
+++ b/contents/parts/formatting-and-links.adoc
@@ -9,15 +9,15 @@ This is possible because it renders contiguous lines as a paragraph.
 The idea of this writing technique is to give every sentence, or independent clause, its own line.
 Some of the benefits to writing content this way are:
 
-* The Git diff of a sentence is easier to read when it is isolated to a single line
-** This helps reviewing changes faster
-* It calls attention to potentially long-winded sentences
-* Sentences containing long lists can be expanded to multiple lines
-** List items within these sentences can be easily added or removed
-* Individual sentences can be commented out using Asciidoctor's comments
-* Sentences can be swapped by swapping the content of two lines
-* It gives the source document a similar to feel code
-** Though it can be done, it is rare to write multiple statements per line in code
+* The Git diff of a sentence is easier to read when it is isolated to a single line.
+** This helps reviewing changes faster.
+* It calls attention to potentially long-winded sentences.
+* Sentences containing long lists can be expanded to multiple lines.
+** List items within these sentences can be easily added or removed.
+* Individual sentences can be commented out using Asciidoctor's comments.
+* Sentences can be swapped by swapping the content of two lines.
+* It gives the source document a similar to feel code.
+** Though it can be done, it is rare to write multiple statements per line in code.
 
 Therefore, to improve the readability and user-friendliness of the guide's source, avoid writing a paragraph, or multiple sentences, on a single line.
 

--- a/contents/parts/formatting-and-links.adoc
+++ b/contents/parts/formatting-and-links.adoc
@@ -20,7 +20,7 @@ Some benefits of writing content this way are:
 ** List items within these sentences can be easily added or removed.
 * Individual sentences can be commented out using Asciidoctor's comments.
 * Sentences can be swapped by swapping the content of two lines.
-* It gives the source document a similar to feel code.
+* It gives the document's source a similar feel to code.
 ** Though it can be done, it is rare to write multiple statements per line of code.
 
 Therefore, to improve the readability and user-friendliness of the guide's source, avoid writing a paragraph, or multiple sentences, on a single line.

--- a/contents/parts/formatting-and-links.adoc
+++ b/contents/parts/formatting-and-links.adoc
@@ -11,7 +11,7 @@ Asciidoctor provides the powerful ability to write a sentence per line.
 The idea of this writing technique is to give every sentence, or independent clause, its own line.
 This is possible because Asciidoctor renders contiguous lines as a paragraph.
 More information about this technique can be learned from {link-adoc-zen}.
-Some of the benefits to writing content this way are:
+Some benefits of writing content this way are:
 
 * The Git diff of a sentence is easier to read when it is isolated to a single line.
 ** This helps reviewing changes faster.

--- a/contents/parts/formatting-and-links.adoc
+++ b/contents/parts/formatting-and-links.adoc
@@ -2,7 +2,7 @@
 
 A common decision that a writer needs to make is whether to style a particular piece of text and if so, what style to use. This section tackles those decisions as well as those around the usage of hyperlinks.
 
-=== Write a sentence per line
+=== Write one sentence per line
 
 :uri-adoc-spl: https://asciidoctor.org/docs/asciidoc-recommended-practices/#one-sentence-per-line
 :uri-adoc-zen: https://youtu.be/Aq2USmIItrs?t=3505
@@ -10,10 +10,11 @@ A common decision that a writer needs to make is whether to style a particular p
 :link-adoc-spl: {uri-adoc-spl}[AsciiDoc's Recommended Practices]
 :link-adoc-zen: {uri-adoc-zen}[Dan Allen's "Discover the Zen of Writing With Asciidoctor" talk]
 
-Writing a sentence per line is a recommended practice for composing documents in AsciiDoc.
+Writing one sentence per line is a recommended practice for composing documents in AsciiDoc.
 This writing technique gives every sentence, or independent clause, its own line.
 Since AsciiDoc renders contiguous lines as a paragraph, the resulting content will not include the line breaks.
 More information on this technique can be learned from {link-adoc-spl} as well as {link-adoc-zen}.
+
 Some benefits of writing content this way are:
 
 * The Git diff of a sentence is easier to read when it is isolated to a single line.
@@ -24,7 +25,7 @@ Some benefits of writing content this way are:
 * Individual sentences can be commented out using comments.
 * Sentences can be swapped by swapping the content of two lines.
 * It gives the document's source a similar feel to code.
-** Though it can be done, it is rare to write multiple statements per line of code.
+** Though it may be allowed, it is rare to write multiple statements per line of code.
 
 Therefore, to improve the readability and user-friendliness of the guide's source, avoid writing a paragraph, or multiple sentences, on a single line.
 

--- a/contents/parts/formatting-and-links.adoc
+++ b/contents/parts/formatting-and-links.adoc
@@ -4,13 +4,16 @@ A common decision that a writer needs to make is whether to style a particular p
 
 === Write a sentence per line
 
+:uri-adoc-spl: https://asciidoctor.org/docs/asciidoc-recommended-practices/#one-sentence-per-line
 :uri-adoc-zen: https://youtu.be/Aq2USmIItrs?t=3505
+
+:link-adoc-spl: {uri-adoc-spl}[AsciiDoc's Recommended Practices]
 :link-adoc-zen: {uri-adoc-zen}[Dan Allen's "Discover the Zen of Writing With Asciidoctor" talk]
 
-Asciidoctor provides the powerful ability to write a sentence per line.
-The idea of this writing technique is to give every sentence, or independent clause, its own line.
-This is possible because Asciidoctor renders contiguous lines as a paragraph.
-More information about this technique can be learned from {link-adoc-zen}.
+Writing a sentence per line is a recommended practice for composing documents in AsciiDoc.
+This writing technique gives every sentence, or independent clause, its own line.
+Since AsciiDoc renders contiguous lines as a paragraph, the resulting content will not include the line breaks.
+More information on this technique can be learned from {link-adoc-spl} as well as {link-adoc-zen}.
 Some benefits of writing content this way are:
 
 * The Git diff of a sentence is easier to read when it is isolated to a single line.
@@ -18,7 +21,7 @@ Some benefits of writing content this way are:
 * It calls attention to potentially long-winded sentences.
 * Sentences containing long lists can be expanded to multiple lines.
 ** List items within these sentences can be easily added or removed.
-* Individual sentences can be commented out using Asciidoctor's comments.
+* Individual sentences can be commented out using comments.
 * Sentences can be swapped by swapping the content of two lines.
 * It gives the document's source a similar feel to code.
 ** Though it can be done, it is rare to write multiple statements per line of code.

--- a/contents/parts/formatting-and-links.adoc
+++ b/contents/parts/formatting-and-links.adoc
@@ -21,7 +21,7 @@ Some of the benefits to writing content this way are:
 * Individual sentences can be commented out using Asciidoctor's comments.
 * Sentences can be swapped by swapping the content of two lines.
 * It gives the source document a similar to feel code.
-** Though it can be done, it is rare to write multiple statements per line in code.
+** Though it can be done, it is rare to write multiple statements per line of code.
 
 Therefore, to improve the readability and user-friendliness of the guide's source, avoid writing a paragraph, or multiple sentences, on a single line.
 


### PR DESCRIPTION
Asciidoctor renders contiguous lines as a paragraph. This opens the door to suggest to authors to write a sentence per line. This is a powerful writing technique that I learned years ago from Dan Allen's (the author of Asciidoctor) "Zen of Writing Asciidoctor" presentation (https://youtu.be/Aq2USmIItrs?t=3505).

Most of the Gradle guides that I have touched are written using a paragraph-per-line style. This has a couple of downsides, mainly: it requires the reader to turn on line wrapping; it's tedious to rearrange sentences within a paragraph; and, much more importantly, it makes reading Git diffs of Asciidoctor documents difficult, especially if a small typo was the only change.

This PR isn't concerned with the current Gradle guides. It is only promoting this writing technique to future guide authors. If existing guide authors choose to adopt this, then that's their decision.

I did my best to communicate the benefits of using this technique of writing a sentence per line in this patch. Since the Gradle team hosts all the guides under its GitHub organization, I think these benefits not only apply to the author but also to the Gradle team members that have to interact with and review the author's content.

To dogfood this suggestion, my modifications are written using this technique.